### PR TITLE
fix ola-chart-column to avoid extra td due to commas

### DIFF
--- a/src/OlaChartColumn.js
+++ b/src/OlaChartColumn.js
@@ -22,7 +22,7 @@ class OlaChartColumn extends BodyComponent {
             ${this.renderChildren()}
           </tr>
           <tr>
-            ${sub_children.map(child => `<td style="vertical-align: top"> ${this.renderChildren(child)} </td>`)}
+            ${sub_children.map(child => `<td style="vertical-align: top"> ${this.renderChildren(child)} </td>`).join("")}
           </tr>
         </table>
         `);


### PR DESCRIPTION
Fix:
Add .join("") to the array of children to avoid comma and extra `<td>`