### PR TITLE
add attribute variant to OlaCircle

### DIFF
--- a/src/OlaCircle.js
+++ b/src/OlaCircle.js
@@ -8,11 +8,13 @@ class OlaCircle extends BodyComponent {
     static allowedAttributes = {
         'background-color': 'enum(brand,white,black,gray,gray-light,error,warning,success,pro,premium)',
         'color': 'string',
+        'variant': 'enum(small,medium,big)'
     };
 
     static defaultAttributes = {
         'background-color': 'gray',
         'color': 'white',
+        'variant': 'big'
     };
 
     headStyle() {
@@ -30,13 +32,24 @@ class OlaCircle extends BodyComponent {
     }
 
     render() {
+        const variant = this.getAttribute('variant');
+        const size = {
+            [variant === "small"]: tokens('size-6'),
+            [variant === "medium"]: tokens('size-7'),
+            [variant === "big"]: tokens('size-8')
+        }[true] || null;
+        const textVariant = {
+            [variant === "small"]: 'caption',
+            [variant === "medium"]: 'callout',
+            [variant === "big"]: 'body'
+        }[true] || null;
         return `
     <table class="ola_circle" style="border-radius: 50%; background-color:${tokens(this.getAttribute('background-color'))};">
         <tr>
-            <td class="ola_circle-number">
+            <td class="ola_circle-number" style="width:${size}; height:${size}">
                 ${this.renderMJML(`
                 <ola-text ${this.htmlAttributes({
-            'variant': 'body',
+            'variant': `${textVariant}`,
             'align': 'center',
             'color': this.getAttribute('color'),
             'font-weight': 'bold'

--- a/src/OlaCircle.js
+++ b/src/OlaCircle.js
@@ -8,13 +8,13 @@ class OlaCircle extends BodyComponent {
     static allowedAttributes = {
         'background-color': 'enum(brand,white,black,gray,gray-light,error,warning,success,pro,premium)',
         'color': 'string',
-        'variant': 'enum(small,medium,big)'
+        'size': 'enum(small,medium,big)'
     };
 
     static defaultAttributes = {
         'background-color': 'gray',
         'color': 'white',
-        'variant': 'big'
+        'size': 'big'
     };
 
     headStyle() {
@@ -32,24 +32,24 @@ class OlaCircle extends BodyComponent {
     }
 
     render() {
-        const variant = this.getAttribute('variant');
-        const size = {
-            [variant === "small"]: tokens('size-6'),
-            [variant === "medium"]: tokens('size-7'),
-            [variant === "big"]: tokens('size-8')
+        const size = this.getAttribute('size');
+        const circleSize = {
+            [size === "small"]: tokens('size-6'),
+            [size === "medium"]: tokens('size-7'),
+            [size === "big"]: tokens('size-8')
         }[true] || null;
-        const textVariant = {
-            [variant === "small"]: 'caption',
-            [variant === "medium"]: 'callout',
-            [variant === "big"]: 'body'
+        const textSize = {
+            [size === "small"]: 'caption',
+            [size === "medium"]: 'callout',
+            [size === "big"]: 'body'
         }[true] || null;
         return `
     <table class="ola_circle" style="border-radius: 50%; background-color:${tokens(this.getAttribute('background-color'))};">
         <tr>
-            <td class="ola_circle-number" style="width:${size}; height:${size}">
+            <td class="ola_circle-number" style="width:${circleSize}; height:${circleSize}">
                 ${this.renderMJML(`
                 <ola-text ${this.htmlAttributes({
-            'variant': `${textVariant}`,
+            'variant': `${textSize}`,
             'align': 'center',
             'color': this.getAttribute('color'),
             'font-weight': 'bold'


### PR DESCRIPTION
Hola Oscar! Te propongo añadir un atributo variant al componente OlaCircle. Esta idea surge por la necesidad de usar este componente en el empty state dentro de tablas, antes usábamos el empty state con un barra de progreso, pero para el nuevo monthly wordpress email no teníamos un diseño para esta casuística, ¿te parece que este pueda ser un diseño adecuado para el empty state dentro de tablas?

De ser así sería necesario crear variants para OlaCircle para que se vea correctamente y no deformado el círculo, porque el componente actual tiene width y height fijos. La idea con el variant es que estas propiedades sean variables, al igual que el font-size del texto que renderiza.
<img width="574" alt="Screenshot 2022-03-16 at 12 35 07" src="https://user-images.githubusercontent.com/60382139/158581325-aad0c1e6-5a0a-4047-8a78-1dfec8231ddf.png">
 